### PR TITLE
Introducing base activity

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -23,6 +23,7 @@ android {
 }
 
 dependencies {
+    compile 'com.android.support:appcompat-v7:23.0.1'
     compile 'com.android.support:support-annotations:23.0.1'
     compile 'org.roboguice:roboguice:3.0.1'
     provided 'org.roboguice:roboblender:3.0.1'

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -2,7 +2,9 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
       package="pl.rbolanowski.tw4a">
     <uses-permission android:name="android.permission.INTERNET"/>
-    <application android:label="@string/app_name" android:icon="@drawable/ic_launcher" android:allowBackup="true">
+    <application
+        android:label="@string/app_name" android:icon="@drawable/ic_launcher" android:allowBackup="true"
+        android:theme="@style/AppTheme">
         <activity android:name="MainActivity" android:label="@string/app_name">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/app/src/main/java/pl/rbolanowski/tw4a/BaseActivity.java
+++ b/app/src/main/java/pl/rbolanowski/tw4a/BaseActivity.java
@@ -46,12 +46,12 @@ import com.google.inject.Key;
 import com.google.inject.internal.util.Stopwatch;
 
 import android.annotation.TargetApi;
-import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
 import android.content.res.Configuration;
 import android.os.Build;
 import android.os.Bundle;
+import android.support.v7.app.AppCompatActivity;
 import android.util.AttributeSet;
 import android.view.View;
 
@@ -81,7 +81,7 @@ import android.view.View;
  *
  * @author Mike Burton
  */
-public class BaseActivity extends Activity implements RoboContext {
+public class BaseActivity extends AppCompatActivity implements RoboContext {
     protected EventManager eventManager;
     protected HashMap<Key<?>,Object> scopedObjects = new HashMap<Key<?>, Object>();
 
@@ -99,7 +99,7 @@ public class BaseActivity extends Activity implements RoboContext {
         stopwatch.resetAndLog("RoboActivity inject members without views");
         super.onCreate(savedInstanceState);
         stopwatch.resetAndLog("RoboActivity super onCreate");
-        eventManager.fire(new OnCreateEvent<Activity>(this,savedInstanceState));
+        eventManager.fire(new OnCreateEvent<AppCompatActivity>(this,savedInstanceState));
         stopwatch.resetAndLog("RoboActivity fire event");
     }
 
@@ -118,7 +118,7 @@ public class BaseActivity extends Activity implements RoboContext {
     @Override
     protected void onStart() {
         super.onStart();
-        eventManager.fire(new OnStartEvent<Activity>(this));
+        eventManager.fire(new OnStartEvent<AppCompatActivity>(this));
     }
 
     @Override
@@ -151,7 +151,7 @@ public class BaseActivity extends Activity implements RoboContext {
     @Override
     protected void onDestroy() {
         try {
-            eventManager.fire(new OnDestroyEvent<Activity>(this));
+            eventManager.fire(new OnDestroyEvent<AppCompatActivity>(this));
         } finally {
             try {
                 RoboGuice.destroyInjector(this);
@@ -165,7 +165,7 @@ public class BaseActivity extends Activity implements RoboContext {
     public void onConfigurationChanged(Configuration newConfig) {
         final Configuration currentConfig = getResources().getConfiguration();
         super.onConfigurationChanged(newConfig);
-        eventManager.fire(new OnConfigurationChangedEvent<Activity>(this,currentConfig, newConfig));
+        eventManager.fire(new OnConfigurationChangedEvent<AppCompatActivity>(this,currentConfig, newConfig));
     }
 
     @Override

--- a/app/src/main/java/pl/rbolanowski/tw4a/BaseActivity.java
+++ b/app/src/main/java/pl/rbolanowski/tw4a/BaseActivity.java
@@ -1,0 +1,224 @@
+/*
+ * This file has been copied from roboguice repository and adapted to
+ * our needs..
+ *
+ * Copyright 2009 Michael Burton
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+package pl.rbolanowski.tw4a;
+
+import java.lang.reflect.Constructor;
+import java.util.HashMap;
+import java.util.Map;
+
+import roboguice.RoboGuice;
+import roboguice.activity.event.OnActivityResultEvent;
+import roboguice.activity.event.OnContentChangedEvent;
+import roboguice.activity.event.OnNewIntentEvent;
+import roboguice.activity.event.OnPauseEvent;
+import roboguice.activity.event.OnRestartEvent;
+import roboguice.activity.event.OnResumeEvent;
+import roboguice.activity.event.OnSaveInstanceStateEvent;
+import roboguice.activity.event.OnStopEvent;
+import roboguice.context.event.OnConfigurationChangedEvent;
+import roboguice.context.event.OnCreateEvent;
+import roboguice.context.event.OnDestroyEvent;
+import roboguice.context.event.OnStartEvent;
+import roboguice.event.EventManager;
+import roboguice.inject.ContentViewListener;
+import roboguice.inject.RoboInjector;
+import roboguice.util.RoboContext;
+
+import com.google.inject.Inject;
+import com.google.inject.Key;
+import com.google.inject.internal.util.Stopwatch;
+
+import android.annotation.TargetApi;
+import android.app.Activity;
+import android.content.Context;
+import android.content.Intent;
+import android.content.res.Configuration;
+import android.os.Build;
+import android.os.Bundle;
+import android.util.AttributeSet;
+import android.view.View;
+
+/**
+ * A {@link RoboActivity} extends from {@link Activity} to provide dynamic
+ * injection of collaborators, using Google Guice.<br />
+ * <br />
+ * Your own activities that usually extend from {@link Activity} should now
+ * extend from {@link RoboActivity}.<br />
+ * <br />
+ * If your activities extend from subclasses of {@link Activity} provided by the
+ * Android SDK, we provided Guice versions as well for the most used : see
+ * {@link RoboExpandableListActivity}, {@link RoboListActivity}, and other
+ * classes located in package <strong>roboguice.activity</strong>.<br />
+ * <br />
+ * If we didn't provide what you need, you have two options : either post an
+ * issue on <a href="http://code.google.com/p/roboguice/issues/list">the bug
+ * tracker</a>, or implement it yourself. Have a look at the source code of this
+ * class ({@link RoboActivity}), you won't have to write that much changes. And
+ * of course, you are welcome to contribute and send your implementations to the
+ * RoboGuice project.<br />
+ * <br />
+ * Please be aware that collaborators are not injected into this until you call
+ * {@link #setContentView(int)} (calling any of the overloads of this methods
+ * will work).<br />
+ * <br />
+ *
+ * @author Mike Burton
+ */
+public class BaseActivity extends Activity implements RoboContext {
+    protected EventManager eventManager;
+    protected HashMap<Key<?>,Object> scopedObjects = new HashMap<Key<?>, Object>();
+
+    @Inject ContentViewListener ignored; // BUG find a better place to put this
+    private Stopwatch stopwatch;
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        stopwatch = new Stopwatch();
+        final RoboInjector injector = RoboGuice.getInjector(this);
+        stopwatch.resetAndLog("RoboActivity creation of injector");
+        eventManager = injector.getInstance(EventManager.class);
+        stopwatch.resetAndLog("RoboActivity creation of eventmanager");
+        injector.injectMembersWithoutViews(this);
+        stopwatch.resetAndLog("RoboActivity inject members without views");
+        super.onCreate(savedInstanceState);
+        stopwatch.resetAndLog("RoboActivity super onCreate");
+        eventManager.fire(new OnCreateEvent<Activity>(this,savedInstanceState));
+        stopwatch.resetAndLog("RoboActivity fire event");
+    }
+
+    @Override
+    protected void onSaveInstanceState(Bundle outState) {
+        super.onSaveInstanceState(outState);
+        eventManager.fire(new OnSaveInstanceStateEvent(this, outState));
+    }
+
+    @Override
+    protected void onRestart() {
+        super.onRestart();
+        eventManager.fire(new OnRestartEvent(this));
+    }
+
+    @Override
+    protected void onStart() {
+        super.onStart();
+        eventManager.fire(new OnStartEvent<Activity>(this));
+    }
+
+    @Override
+    protected void onResume() {
+        super.onResume();
+        eventManager.fire(new OnResumeEvent(this));
+    }
+
+    @Override
+    protected void onPause() {
+        super.onPause();
+        eventManager.fire(new OnPauseEvent(this));
+    }
+
+    @Override
+    protected void onNewIntent( Intent intent ) {
+        super.onNewIntent(intent);
+        eventManager.fire(new OnNewIntentEvent(this));
+    }
+
+    @Override
+    protected void onStop() {
+        try {
+            eventManager.fire(new OnStopEvent(this));
+        } finally {
+            super.onStop();
+        }
+    }
+
+    @Override
+    protected void onDestroy() {
+        try {
+            eventManager.fire(new OnDestroyEvent<Activity>(this));
+        } finally {
+            try {
+                RoboGuice.destroyInjector(this);
+            } finally {
+                super.onDestroy();
+            }
+        }
+    }
+
+    @Override
+    public void onConfigurationChanged(Configuration newConfig) {
+        final Configuration currentConfig = getResources().getConfiguration();
+        super.onConfigurationChanged(newConfig);
+        eventManager.fire(new OnConfigurationChangedEvent<Activity>(this,currentConfig, newConfig));
+    }
+
+    @Override
+    public void onContentChanged() {
+        super.onContentChanged();
+        RoboGuice.getInjector(this).injectViewMembers(this);
+        eventManager.fire(new OnContentChangedEvent(this));
+    }
+
+    @Override
+    protected void onActivityResult(int requestCode, int resultCode, Intent data) {
+        super.onActivityResult(requestCode, resultCode, data);
+        eventManager.fire(new OnActivityResultEvent(this, requestCode, resultCode, data));
+    }
+
+    @Override
+    public Map<Key<?>, Object> getScopedObjectMap() {
+        return scopedObjects;
+    }
+
+    @Override
+    public View onCreateView(String name, Context context, AttributeSet attrs) {
+        if (shouldInjectOnCreateView(name))
+            return injectOnCreateView(name, context, attrs);
+        return super.onCreateView(name, context, attrs);
+    }
+
+    @Override
+    @TargetApi(Build.VERSION_CODES.HONEYCOMB)
+    public View onCreateView(View parent, String name, Context context, AttributeSet attrs) {
+        if (shouldInjectOnCreateView(name))
+            return injectOnCreateView(name, context, attrs);
+
+        return super.onCreateView(parent, name, context, attrs);
+    }
+
+    /**
+     * @return true if name begins with a lowercase character (indicating a package) and it doesn't start with com.android
+     */
+    protected static boolean shouldInjectOnCreateView(String name) {
+        return false; // && Character.isLowerCase(name.charAt(0)) && !name.startsWith("com.android") && !name.equals("fragment");
+    }
+
+    protected static View injectOnCreateView(String name, Context context, AttributeSet attrs) {
+        try {
+            final Constructor<?> constructor = Class.forName(name).getConstructor(Context.class, AttributeSet.class);
+            final View view = (View) constructor.newInstance(context, attrs);
+            RoboGuice.getInjector(context).injectMembers(view);
+            RoboGuice.getInjector(context).injectViewMembers(view);
+            return view;
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+}

--- a/app/src/main/java/pl/rbolanowski/tw4a/MainActivity.java
+++ b/app/src/main/java/pl/rbolanowski/tw4a/MainActivity.java
@@ -18,7 +18,7 @@ import static android.widget.AdapterView.AdapterContextMenuInfo;
 import pl.rbolanowski.tw4a.backend.*;
 
 @ContentView(R.layout.main)
-public class MainActivity extends RoboActivity {
+public class MainActivity extends BaseActivity {
 
     @Inject private BackendFactory mBackend;
     @InjectView(android.R.id.list) private ListView mListView;

--- a/app/src/main/res/layout/main.xml
+++ b/app/src/main/res/layout/main.xml
@@ -11,12 +11,11 @@
         android:indeterminate="true"
         android:layout_centerInParent="true"
         />
-
     <ListView
         android:id="@android:id/list"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:visibility="gone"
         />
-
 </RelativeLayout>
+

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <style name="AppTheme" parent="Theme.AppCompat.Light.DarkActionBar"/>
+</resources>
+


### PR DESCRIPTION
Due to the need of using support library we must have our own base `Activity` which implements `RoboGuice` injection interface. According to the RG's wiki

> In case your base activity class already extends a different library, the best way to get all the power of RoboGuice is to copy all the code contained in RoboActivity.

Hence the PR.
