### PR TITLE
Changing application orientation

### DIFF
--- a/app/src/androidTest/java/pl/rbolanowski/tw4a/ConfigureBackendAsyncTaskTest.java
+++ b/app/src/androidTest/java/pl/rbolanowski/tw4a/ConfigureBackendAsyncTaskTest.java
@@ -44,6 +44,16 @@ public class ConfigureBackendAsyncTaskTest extends AndroidMockitoTestCase {
 
     @Test public void changesLoadingAndReadyViewVisibility() throws Exception {
         setUpViews();
+        new ConfigureBackendAsyncTask(mConfigurator, null, null).onPostExecute(null);
+
+        new ConfigureBackendAsyncTask(mConfigurator, mLoadingView, null).onPostExecute(null);
+        assertEquals(View.GONE, mLoadingView.getVisibility());
+
+        setUpViews();
+        new ConfigureBackendAsyncTask(mConfigurator, null, mReadyView).onPostExecute(null);
+        assertEquals(View.VISIBLE, mReadyView.getVisibility());
+
+        setUpViews();
         mTask.onPostExecute(null);
         assertVisibilityChanged();
     }

--- a/app/src/androidTest/java/pl/rbolanowski/tw4a/MainActivityTest.java
+++ b/app/src/androidTest/java/pl/rbolanowski/tw4a/MainActivityTest.java
@@ -5,6 +5,7 @@ import android.support.test.espresso.ViewAction;
 import android.support.test.rule.ActivityTestRule;
 import android.support.test.runner.AndroidJUnit4;
 import android.widget.EditText;
+import android.content.pm.ActivityInfo;
 
 import java.io.File;
 
@@ -79,6 +80,17 @@ public class MainActivityTest extends AndroidMockitoTestCase {
             )));
     }
 
+    @Test public void changesOrientation() {
+        swapOrientation(Orientation.Portrait);
+        listViewShowsTasks();
+        swapOrientation(Orientation.Landscape);
+        listViewShowsTasks();
+    }
+
+    private void swapOrientation(Orientation orientation) {
+        mActivity.setRequestedOrientation(orientation.getRaw());
+    }
+
     @Test public void contextMenuVisibleAferLongClick() {
         onData(anything()).inAdapterView(withId(android.R.id.list)).atPosition(0).perform(longClick());
         onView(withText(R.string.menu_done)).check(matches(isDisplayed()));
@@ -145,6 +157,23 @@ public class MainActivityTest extends AndroidMockitoTestCase {
     private static ViewAction submit() {
         final int btnSubmit = 66;
         return pressKey(btnSubmit);
+    }
+
+}
+
+enum Orientation {
+
+    Portrait  (ActivityInfo.SCREEN_ORIENTATION_PORTRAIT),
+    Landscape (ActivityInfo.SCREEN_ORIENTATION_LANDSCAPE);
+
+    private int mRaw;
+
+    Orientation(int value) {
+        mRaw = value;
+    }
+
+    public int getRaw() {
+        return mRaw;
     }
 
 }

--- a/app/src/main/java/pl/rbolanowski/tw4a/MainActivity.java
+++ b/app/src/main/java/pl/rbolanowski/tw4a/MainActivity.java
@@ -53,8 +53,14 @@ abstract class ResourceLoadingAsyncTask extends AsyncTask<Void, Void, Void> {
 
     @Override
     protected void onPostExecute(Void someVoid) {
-        mLoadingView.setVisibility(View.GONE);
-        mReadyView.setVisibility(View.VISIBLE);
+        setVisibility(mLoadingView, View.GONE);
+        setVisibility(mReadyView, View.VISIBLE);
+    }
+
+    private static void setVisibility(View view, int value) {
+        if (view != null) {
+            view.setVisibility(value);
+        }
     }
 
 }

--- a/app/src/main/java/pl/rbolanowski/tw4a/MainActivity.java
+++ b/app/src/main/java/pl/rbolanowski/tw4a/MainActivity.java
@@ -32,7 +32,7 @@ public class MainActivity extends BaseActivity {
                 public void run() {
                     FragmentManager manager = getSupportFragmentManager();
                     FragmentTransaction transaction = manager.beginTransaction();
-                    transaction.add(android.R.id.content, new TaskListFragment());
+                    transaction.replace(android.R.id.content, new TaskListFragment());
                     transaction.commit();
                 }
             })

--- a/app/src/test/java/pl/rbolanowski/tw4a/ConfigureBackendAsyncTaskTest.java
+++ b/app/src/test/java/pl/rbolanowski/tw4a/ConfigureBackendAsyncTaskTest.java
@@ -8,17 +8,38 @@ import org.junit.Test;
 import pl.rbolanowski.tw4a.backend.BackendFactory;
 import pl.rbolanowski.tw4a.backend.Configurator;
 import pl.rbolanowski.tw4a.backend.Database;
-import pl.rbolanowski.tw4a.test.AndroidMockitoTestCase;
 
 import static org.mockito.Mockito.*;
+import static org.junit.Assert.*;
 import static org.junit.Assume.assumeTrue;
 
-public class ConfigureBackendAsyncTaskTest extends AndroidMockitoTestCase {
+public class ConfigureBackendAsyncTaskTest {
 
     private static class FakeException extends Configurator.BackendException {}
 
-    private View mLoadingView = new View(getTargetContext());
-    private View mReadyView = new View(getTargetContext());
+    // android objects do nothing in unit tests
+    private static class ViewFake extends View {
+
+        private int mVisibility;
+
+        public ViewFake() {
+            super(null);
+        }
+
+        @Override
+        public void setVisibility(int value) {
+            mVisibility = value;
+        }
+
+        @Override
+        public int getVisibility() {
+            return mVisibility;
+        }
+
+    }
+
+    private View mLoadingView = new ViewFake();
+    private View mReadyView = new ViewFake();
     private Configurator mConfigurator;
     private ConfigureBackendAsyncTask mTask;
 


### PR DESCRIPTION
Fixed changing orientation of the application.

Changing orientation was impossible due to
- assuming that there were always loading and content views
- adding a fragment instead of replacing an existing fragment
